### PR TITLE
fixing bug in docker run command

### DIFF
--- a/data-ihaskell.sh
+++ b/data-ihaskell.sh
@@ -13,7 +13,7 @@ then
 else
     if [ "$1" == "run" ]
     then
-        docker run -it --volume `pwd`/IHaskell/notebooks:/notebooks --publish 8888:8888 datahaskell-ihaskell
+        docker run -it --volume `pwd`:/notebooks --publish 8888:8888 datahaskell-ihaskell
     else
         if [ "$1" == "rebuild" ]
         then

--- a/data-ihaskell.sh
+++ b/data-ihaskell.sh
@@ -13,7 +13,7 @@ then
 else
     if [ "$1" == "run" ]
     then
-        docker run -it --volume %cd%:/notebooks --publish 8888:8888 datahaskell-ihaskell
+        docker run -it --volume `pwd`:/notebooks --publish 8888:8888 datahaskell-ihaskell
     else
         if [ "$1" == "rebuild" ]
         then

--- a/data-ihaskell.sh
+++ b/data-ihaskell.sh
@@ -13,7 +13,7 @@ then
 else
     if [ "$1" == "run" ]
     then
-        docker run -it --volume `pwd`/notebooks --publish 8888:8888 datahaskell-ihaskell
+        docker run -it --volume `pwd`/IHaskell/notebooks:/notebooks --publish 8888:8888 datahaskell-ihaskell
     else
         if [ "$1" == "rebuild" ]
         then

--- a/data-ihaskell.sh
+++ b/data-ihaskell.sh
@@ -13,7 +13,7 @@ then
 else
     if [ "$1" == "run" ]
     then
-        docker run -it --volume `pwd`:/notebooks --publish 8888:8888 datahaskell-ihaskell
+        docker run -it --volume `pwd`/notebooks --publish 8888:8888 datahaskell-ihaskell
     else
         if [ "$1" == "rebuild" ]
         then


### PR DESCRIPTION
On mac osx the %cd% returns an error: 
```
docker: Error response from daemon: create %cd%: "%cd%" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed.
```
Changing to `pwd` resolves the error.